### PR TITLE
feat(user): User 엔티티 및 레포지토리 추가

### DIFF
--- a/src/main/java/com/example/outsourcing_project/domain/user/domain/User.java
+++ b/src/main/java/com/example/outsourcing_project/domain/user/domain/User.java
@@ -1,0 +1,33 @@
+package com.example.outsourcing_project.domain.user.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 20)
+    private String username;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private UserRole userRole;
+}

--- a/src/main/java/com/example/outsourcing_project/domain/user/domain/UserRepository.java
+++ b/src/main/java/com/example/outsourcing_project/domain/user/domain/UserRepository.java
@@ -1,0 +1,8 @@
+package com.example.outsourcing_project.domain.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/example/outsourcing_project/domain/user/domain/UserRole.java
+++ b/src/main/java/com/example/outsourcing_project/domain/user/domain/UserRole.java
@@ -1,0 +1,8 @@
+package com.example.outsourcing_project.domain.user.domain;
+
+import java.util.Arrays;
+
+public enum UserRole {
+    ADMIN, USER;
+
+}


### PR DESCRIPTION
## 📌 개요
users 테이블에 기반하여 User 엔티티와 역할(Enum) 정의, 레포지토리 구성

## ✅ 작업 사항
- [x] User 엔티티 구현 (id, email, username, password, name, role, createdAt 등)
- [x] UserRole enum 추가 (ADMIN, USER)
- [x] UserRepository 생성 (JpaRepository 상속)

## 🔍 리뷰 요청 포인트
- User 엔티티 필드 및 제약 조건이 users 테이블 정의와 잘 매핑되어 있는지
- Enum 타입(UserRole) 처리 방식 괜찮은지 (예외처리 포함)

## 💬 기타 사항
- 이후 BaseEntity 적용 예정 (createdAt, updatedAt 공통화)
- 삭제 관련 isDeleted, deletedAt도 추후 soft delete 로직에 활용 예정
