### PR TITLE
feat(auth): CustomAuthenticationEntryPoint 도입 및 JWT 인증 예외 처리 개선

### DIFF
--- a/src/main/java/com/example/outsourcing_project/global/config/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/outsourcing_project/global/config/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,55 @@
+package com.example.outsourcing_project.global.config;
+
+import com.example.outsourcing_project.global.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인증되지 않은 사용자가 인증이 필요한 API 요청 시,
+ * 커스텀 JSON 응답을 반환하는 클래스입니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    // JSON 직렬화를 위한 ObjectMapper 주입
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 인증 실패 시 자동으로 호출되는 메서드
+     * @param request  클라이언트 요청 정보
+     * @param response 응답 정보 객체 (여기에 JSON으로 직접 작성)
+     * @param authException 인증 실패 예외 정보
+     */
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException {
+
+        // 1. 실패 메시지를 공통 응답 포맷(ApiResponse)으로 구성
+        ApiResponse<Object> errorResponse = ApiResponse.fail("Jwt 토큰이 필요합니다");
+
+        // 2. JSON 문자열로 직렬화
+        String responseBody = objectMapper.writeValueAsString(errorResponse);
+
+        // 3. 응답의 Content-Type을 JSON으로 설정
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        // 4. 응답의 HTTP 상태 코드를 401 (Unauthorized)로 설정
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+
+        // 5. 한글 깨짐 방지를 위해 인코딩 설정
+        response.setCharacterEncoding("UTF-8");
+
+        // 6. JSON 형태로 메시지를 클라이언트에 출력
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/com/example/outsourcing_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/outsourcing_project/global/config/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.web.servletapi.SecurityContextHolderAwareReq
 public class SecurityConfig {
 
     private final JwtFilter jwtFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -43,6 +44,15 @@ public class SecurityConfig {
                         //.requestMatchers("/api/normal/**").hasRole("NORMAL")
                         .anyRequest().authenticated()
                 )
+
+                //필터 등록
+
+                .exceptionHandling(configurer ->
+                        configurer
+                                .authenticationEntryPoint(customAuthenticationEntryPoint)
+//                                .accessDeniedHandler(customAccessDeniedHandler)
+                )
+
                 .build();
     }
 }

--- a/src/main/java/com/example/outsourcing_project/global/filter/JwtFilter.java
+++ b/src/main/java/com/example/outsourcing_project/global/filter/JwtFilter.java
@@ -34,22 +34,11 @@ public class JwtFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-
-        String requestURI = request.getRequestURI();
-
-        if (
-                requestURI.startsWith("/api/login") ||
-                requestURI.startsWith("/api/signup") ||
-                requestURI.startsWith("/api/auth/register") || //회원가입api
-                requestURI.startsWith("/refresh-token")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         String bearerJwt = request.getHeader("Authorization");
 
         if (bearerJwt == null || !bearerJwt.startsWith("Bearer ")) {
-            throw new UnauthorizedException("JWT 토큰이 필요합니다.");
+            filterChain.doFilter(request, response);
+            return;
         }
 
         String jwt = jwtUtil.substringToken(bearerJwt);


### PR DESCRIPTION
feat(auth): CustomAuthenticationEntryPoint 도입 및 JWT 인증 예외 처리 개선

- 인증 실패 시 커스텀 JSON 응답 반환 구현
- JwtFilter 예외 처리 로직 정리 및 중복 인증 제외 로직 제거
- SecurityConfig 리팩토링하여 필터 및 인증 예외 핸들러 등록 간결화

chore: 불필요한 인증 제외 URL 검사 로직 삭제

## 📌 개요
JWT 인증 예외 처리 방식을 개선하고, Security 설정 및 필터 로직을 리팩토링하여 코드 가독성과 유지보수성을 향상시켰습니다.

## ✅ 작업 사항
- CustomAuthenticationEntryPoint 구현 및 적용
- JwtFilter 내 중복 인증 제외 URL 검사 로직 삭제
- SecurityConfig 내 필터 및 예외 핸들러 등록 간소화 및 리팩토링

## 🔍 리뷰 요청 포인트
- 인증 예외 처리 흐름이 자연스러운지 확인 부탁드립니다.
- Security 설정에서 권한 및 필터 순서가 적절한지 검토 부탁드립니다.
- JWT 관련 필터 예외 처리 누락 부분 없는지 확인 부탁드립니다.

## 💬 기타 사항

