### PR TITLE
[#65] refactor: 공통 응답 포맷 통일

### DIFF
--- a/src/main/java/com/example/outsourcing_project/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/outsourcing_project/domain/user/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.example.outsourcing_project.domain.user.controller;
 
 import com.example.outsourcing_project.domain.user.controller.dto.RegisterRequestDto;
-import com.example.outsourcing_project.domain.user.controller.dto.UserResponseDto;
 import com.example.outsourcing_project.domain.user.service.UserService;
+import com.example.outsourcing_project.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
@@ -19,8 +19,8 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/register")
-    public ResponseEntity<UserResponseDto> register(@RequestBody @Valid RegisterRequestDto requestDto) {
-        UserResponseDto responseDto = userService.register(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
+    public ResponseEntity<ApiResponse<Void>> register(@Valid @RequestBody  RegisterRequestDto requestDto) {
+        userService.register(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(null, "화원가입이 완료되었습니다."));
     }
 }

--- a/src/main/java/com/example/outsourcing_project/domain/user/service/UserService.java
+++ b/src/main/java/com/example/outsourcing_project/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.example.outsourcing_project.domain.user.domain.model.User;
 import com.example.outsourcing_project.domain.user.domain.repository.UserRepository;
 import com.example.outsourcing_project.global.enums.UserRoleEnum;
 import com.example.outsourcing_project.global.exception.BadRequestException;
+import com.example.outsourcing_project.global.exception.ConflictException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,15 +20,15 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public UserResponseDto register(RegisterRequestDto dto) {
+    public void register(RegisterRequestDto dto) {
         // 이메일 중복 체크
         if (userRepository.existsByEmail(dto.getEmail())) {
-            throw new BadRequestException("이미 사용 중인 이메일입니다.");
+            throw new ConflictException("이미 사용 중인 이메일입니다.");
         }
 
         // 아이디 중복 체크
         if (userRepository.existsByUsername(dto.getUsername())) {
-            throw new BadRequestException("이미 사용 중인 아이디입니다.");
+            throw new ConflictException("이미 사용 중인 아이디입니다.");
         }
 
         // 비밀번호 암호화
@@ -42,16 +43,7 @@ public class UserService {
                 .build();
 
         // 저장
-        User savedUser = userRepository.save(user);
+        userRepository.save(user);
 
-        // 응답 DTO 반환
-        return UserResponseDto.builder()
-                .id(savedUser.getId())
-                .username(savedUser.getUsername())
-                .email(savedUser.getEmail())
-                .name(savedUser.getName())
-                .role(savedUser.getRole().name())
-                .createdAt(savedUser.getCreatedAt())
-                .build();
     }
 }

--- a/src/main/java/com/example/outsourcing_project/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/outsourcing_project/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .addFilterBefore(jwtFilter, SecurityContextHolderAwareRequestFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         // 회원가입, 로그인은 인증 제외
-                        .requestMatchers("/api/login","/api/signup", "/api/auth/register").permitAll()
+                        .requestMatchers("/api/login", "/api/auth/register").permitAll()
                         .requestMatchers("/error").permitAll()
                         .requestMatchers("/refresh-token").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")

--- a/src/main/java/com/example/outsourcing_project/global/exception/ConflictException.java
+++ b/src/main/java/com/example/outsourcing_project/global/exception/ConflictException.java
@@ -1,0 +1,11 @@
+package com.example.outsourcing_project.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.CONFLICT)
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 📌 개요
기존 회원가입 API 응답 형식을 공통 응답 포맷으로 통일하고 회원 정보 반환 대신 메시지만 제공하도록 변경했습니다.

프론트 흐름상 회원가입 후 로그인 페이지로 이동하기 때문에 회원 정보 반환이 불필요
ApiResponse를 사용하여 응답 일관성 유지
중복 에러에 적절한 HTTP 상태코드(409 Conflict) 적용

## ✅ 작업 사항
UserController:
ResponseEntity<UserResponseDto> → ResponseEntity<ApiResponse<Void>> 변경
반환 값: 메시지만 포함된 공통 응답으로 수정

UserService:
반환 타입 UserResponseDto 제거 → void로 변경
이메일/아이디 중복 시 BadRequestException → ConflictException으로 교체

SecurityConfig:
/api/signup 인증 제외 → 제거
ConflictException 추가 (409 상태 반환)

## 🔍 리뷰 요청 포인트
- 더 개선할 부분 없는지 확인 부탁드립니다.

## 💬 기타 사항
- 관련 이슈: #58

---
