### PR TITLE
fix : 댓글 생성 시 id 값도 반환되도록 수정

### DIFF
--- a/src/main/java/com/example/outsourcing_project/domain/comments/controller/CommentCreateResponseDto.java
+++ b/src/main/java/com/example/outsourcing_project/domain/comments/controller/CommentCreateResponseDto.java
@@ -1,8 +1,6 @@
 package com.example.outsourcing_project.domain.comments.controller;
 
 import com.example.outsourcing_project.domain.comments.model.entity.Comments;
-import com.example.outsourcing_project.domain.task.domain.model.Task;
-import com.example.outsourcing_project.domain.user.domain.model.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,8 +21,10 @@ public class CommentCreateResponseDto {
     private LocalDateTime createdAt;
 
     public CommentCreateResponseDto(Comments comment) {
+        this.id = comment.getId();
         this.content = comment.getContent();
         this.taskId = comment.getTask().getId();
         this.userId = comment.getUser().getId();
+        this.createdAt = comment.getCreatedAt();
     }
 }


### PR DESCRIPTION
## 📌 개요
댓글 생성 시 id 값도 반환되도록 수정

## ✅ 작업 사항
- 댓글 생성 시 id 값도 반환되도록 수정

## 🔍 리뷰 요청 포인트
-  댓글 생성 시 id 값도 반환되도록 수정했습니다.
